### PR TITLE
Text-based answer parsing

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -10,7 +10,7 @@ unicode better.
 # Note to self: Keep this script working with
 # both "python" (2.7.x) and "python3"!
 
-__author__ = "Henrik Laban Torstensson, Andreas Söderlund, Timmy Larsson, Niklas Bolmdahl"
+__author__ = "Henrik Laban Torstensson, Andreas Söderlund, Timmy Larsson, Niklas Bolmdahl, Drahflow"
 __license__ = "MIT"
 
 import argparse
@@ -26,7 +26,10 @@ import signal
 import sys
 import time
 import zipfile
+import re
+from hashlib import md5
 from shutil import rmtree
+from collections import defaultdict, deque
 
 if sys.version_info >= (3,):
     from io import BytesIO as FileLike
@@ -34,7 +37,7 @@ else:
     from cStringIO import StringIO as FileLike
 
 
-def processWorker(iq, oq):
+def typographicAnalyzeWorker(iq, oq):
     signal.signal(signal.SIGINT, signal.SIG_IGN) # Processes will receive SIGINT on Ctrl-C in main program. Just ignore it.
     for odtFilename, odtContent in iter(iq.get, "STOP"):
         resDict = {}
@@ -51,6 +54,111 @@ def processWorker(iq, oq):
         odtFile.close()
 
         oq.put(resDict)
+
+def normalizeWord(s):
+    return re.sub('[^a-zA-Z0-9äöüÄÖÜß]', '', s)
+
+def parseAnswers(text, questions, index, MATCHLEN):
+    answers = defaultdict(deque)
+
+    quesPos = None
+    currentyKey = questions[0][0]
+    words = text.split()
+    nWords = [normalizeWord(w) for w in words]
+
+    def locateInQuestions(pos, valid):
+        if pos >= len(nWords) - MATCHLEN: return None
+
+        for i in [i for i in index[nWords[pos]] if valid(i)]:
+            found = True
+            for j in range(0, MATCHLEN):
+                if nWords[pos + j] != questions[i + j][1]:
+                    found = False
+                    break
+            if found: return i + 1
+        return None
+
+    for textPos in range(0, len(words)):
+        if quesPos is not None:
+            if nWords[textPos] == questions[quesPos][1]:
+                quesPos = quesPos + 1
+            else:
+                newPos = locateInQuestions(textPos, lambda i: i >= quesPos + 1)
+                if newPos is None:
+                    newPos = locateInQuestions(textPos, lambda i: i < quesPos + 1)
+                quesPos = newPos
+        else:
+            quesPos = locateInQuestions(textPos, lambda i: True)
+
+        if quesPos is None or quesPos >= len(questions):
+            answers[currentyKey].append(words[textPos])
+        else:
+            if questions[quesPos][0] != '   ':
+                currentyKey = questions[quesPos][0]
+
+    for k in answers.keys():
+        # eliminate random footnote numbers
+        while answers[k] and re.match("^.?\\d+.?$", answers[k][0]):
+            answers[k].popleft()
+        while answers[k] and re.match("^.?\\d+.?$", answers[k][-1]):
+            answers[k].pop()
+
+        answers[k] = " ".join(answers[k])
+
+    return answers
+
+
+def textBasedAnalyzeWorker(iq, oq):
+    signal.signal(signal.SIGINT, signal.SIG_IGN) # Processes will receive SIGINT on Ctrl-C in main program. Just ignore it.
+
+    MATCHLEN = 7
+
+    questions = []
+    with open('consultation-document_en.dat', 'r') as consultation:
+        for line in consultation:
+            key = line[0:3]
+            for word in line[3:].split():
+                questions.append((key, normalizeWord(word)))
+
+    index = defaultdict(list)
+    for i in range(0, len(questions) - MATCHLEN):
+        index[questions[i][1]].append(i)
+
+    for filename, content in iter(iq.get, "STOP"):
+        tmpname = md5(filename.encode('utf-8')).hexdigest()
+        text = ''
+
+        fileending = filename.lower()[-5::]
+        if fileending.endswith(".pdf"):
+            try:
+                with open(tmpname + '.pdf', 'w') as pdf:
+                    if sys.version_info >= (3,):
+                        pdf.buffer.write(content)
+                    else:
+                        pdf.write(content)
+                # execline = 'unoconv -f odt -o ' + odtTempFileName + ' '+ thisTempFileName
+                subprocess.call('pdftotext %s.pdf %s.txt' % (tmpname, tmpname), shell=True)
+                with open(tmpname + '.txt', 'r') as txt:
+                    text = txt.read()
+            finally:
+                try:
+                    os.remove(tmpname + '.pdf')
+                    os.remove(tmpname + '.txt')
+                except:
+                    pass
+        else:
+            continue
+
+        answers = parseAnswers(text, questions, index, MATCHLEN)
+
+        print ("%s -------------------------" % (filename))
+        print (answers['600'] or "<600 unparsed>")
+        print (answers['020'] or "<020 unparsed>")
+
+        oq.put({
+            'name': answers['600'],
+            'answers': answers,
+        })
 
 
 class ConsultationZipHandler:
@@ -125,7 +233,7 @@ class ConsultationZipHandler:
             else:
                 self.languageDict[language] = {"count": 1}
 
-    def analyze(self, randomize=False, showProgress=False, printNames=False, numProcesses=1, numberOfFiles=0, queueSize=100, filePattern="*", skip=0, wipeDatabase=False, convert2odt=False):
+    def analyze(self, handleFile, worker, randomize=False, showProgress=False, printNames=False, numProcesses=1, numberOfFiles=0, queueSize=100, filePattern="*", skip=0, wipeDatabase=False, convert2odt=False):
         if numberOfFiles == 0:
             numOfFilesToAnalyze = self.getCount()
         else:
@@ -146,7 +254,7 @@ class ConsultationZipHandler:
         resultQueue = multiprocessing.Queue()
         processes = []
         for i in range(numProcesses):
-            process = multiprocessing.Process(name="{}".format(i + 1), target=processWorker, args=[inputQueue, resultQueue])
+            process = multiprocessing.Process(name="{}".format(i + 1), target=worker, args=[inputQueue, resultQueue])
             process.start()
             processes.append(process)
         startTime = time.time()
@@ -161,7 +269,6 @@ class ConsultationZipHandler:
                 if convert2odt:
                     tempdir = tempfile.mkdtemp(prefix="eucrcon-")
                 for filename in filter(lambda x: fnmatch.fnmatch(x.lower(), filePattern), filenames):
-                    fileending = filename.lower()[-5::]
                     if skip:
                         skip -= 1
                         continue
@@ -169,29 +276,12 @@ class ConsultationZipHandler:
                         print("Aborting after enqueuing {} files".format(numberOfFiles))
                         abort = True
                         break
-                    if fileending.endswith(".odt"):
-                        odtFilename = filename
-                        odtContent = zipFile.read(odtFilename)
-    
-                        inputQueue.put((odtFilename, odtContent))
-                    else:
-                        if not convert2odt:
-                            continue
-                        if fileending.endswith(".doc"):
-                            self.convertFiles(tempdir, zipFile, filename, inputQueue, ".doc")
-                        elif   fileending.endswith(".docx"):
-                            self.convertFiles(tempdir, zipFile, filename, inputQueue, ".docx")
-                        elif fileending.endswith(".rtf"):
-                            self.convertFiles(tempdir, zipFile, filename, inputQueue, ".rtf")
-                        elif fileending.endswith(".pdf"):
-                            self.convertFiles(tempdir, zipFile, filename, inputQueue, ".pdf")
-                        else: 
-                            continue 
+
                     if printNames:
-                        print("Enqueuing {}...".format(filename))
-                    
-                    
-                    
+                        print("Handling {}...".format(filename))
+
+                    handleFile(inputQueue, zipFile, filename)
+
                     count += 1
                     if showProgress:
                         if count % showProgress == 0:
@@ -248,7 +338,7 @@ class ConsultationZipHandler:
 
     def listFiles(self):
         return self.fileList
-    
+
     def getCount(self):
         return self.count
 
@@ -275,7 +365,7 @@ class ConsultationZipHandler:
         for (lang, langDict) in self.languageDict.items():
             resList.append((lang, langDict["count"]))
         return sorted(resList, reverse=True, key=lambda tup: tup[1])
-    
+
     def getExtensionCount(self):
         resList = []
         for (ext, extDict) in self.extensionDict.items():
@@ -349,12 +439,39 @@ def parse_args(availableCommands):
 
     return parser.parse_args()
 
+def typographicAnalyze(queue, zipFile, filename, convert2odt):
+    fileending = filename.lower()[-5::]
+    if fileending.endswith(".odt"):
+        odtFilename = filename
+        odtContent = zipFile.read(odtFilename)
+
+        queue.put((odtFilename, odtContent))
+
+    else:
+        if not convert2odt:
+            return
+        if fileending.endswith(".doc"):
+            self.convertFiles(tempdir, zipFile, filename, queue, ".doc")
+        elif   fileending.endswith(".docx"):
+            self.convertFiles(tempdir, zipFile, filename, queue, ".docx")
+        elif fileending.endswith(".rtf"):
+            self.convertFiles(tempdir, zipFile, filename, queue, ".rtf")
+        elif fileending.endswith(".pdf"):
+            self.convertFiles(tempdir, zipFile, filename, queue, ".pdf")
+        else:
+            return
+
+
+def textBasedAnalyze(queue, zipFile, filename):
+    content = zipFile.read(filename)
+    queue.put((filename, content))
+
 
 def main():
     """Main function for running the analyzer.
     Options will be parsed from the command line."""
 
-    availableCommands = ["analyze", "list-forms", "stats"]
+    availableCommands = ["analyze", "analyze_text", "list-forms", "stats"]
 
     args = parse_args(availableCommands)
 
@@ -394,7 +511,22 @@ def main():
         print("")
         count += zipHandler.getCount()
     elif args.command == "analyze":
-        zipHandler.analyze(numProcesses=args.processes,
+        zipHandler.analyze(lambda q, z, f: typographicAnalyze(q, z, f, args.convert2odt),
+                           typographicAnalyzeWorker,
+                           numProcesses=args.processes,
+                           randomize=args.randomize,
+                           showProgress=args.progress,
+                           printNames=args.printNames,
+                           numberOfFiles=args.numberOfFiles,
+                           queueSize=args.queueSize,
+                           filePattern=args.filePattern,
+                           skip=args.offset,
+                           convert2odt=args.convert2odt,
+                           wipeDatabase=args.wipeDatabase)
+    elif args.command == "analyze_text":
+        zipHandler.analyze(textBasedAnalyze,
+                           textBasedAnalyzeWorker,
+                           numProcesses=args.processes,
                            randomize=args.randomize,
                            showProgress=args.progress,
                            printNames=args.printNames,

--- a/consultation-document_en.dat
+++ b/consultation-document_en.dat
@@ -1,0 +1,1776 @@
+    Public Consultation
+    on the review of the EU copyright rules
+    Contents
+    I.
+    Introduction ................................................................................................................... 2
+    A.
+    Context of the consultation ............................................................................................. 2
+    B.
+    How to submit replies to this questionnaire .................................................................... 3
+    C.
+    Confidentiality ................................................................................................................. 3
+    II.
+    Rights and the functioning of the Single Market ....................................................... 7
+    A.
+    Why is it not possible to access many online content services from anywhere in
+    Europe?....................................................................................................................................... 7
+    B.
+    Is there a need for more clarity as regards the scope of what needs to be authorised (or
+    not) in digital transmissions? .................................................................................................... 10
+    1. The act of “making available” ....................................................................................... 10
+    2. Two rights involved in a single act of exploitation ....................................................... 11
+    3. Linking and browsing.................................................................................................... 12
+    4. Download to own digital content .................................................................................. 13
+    C.
+    Registration of works and other subject matter – is it a good idea? .............................. 14
+    D.
+    How to improve the use and interoperability of identifiers .......................................... 15
+    E.
+    Term of protection – is it appropriate? .......................................................................... 15
+    III. Limitations and exceptions in the Single Market ..................................................... 16
+    A.
+    Access to content in libraries and archives ................................................................... 19
+    1. Preservation and archiving ............................................................................................ 19
+    2. Off-premises access to library collections..................................................................... 20
+    3. E – lending .................................................................................................................... 21
+    4. Mass digitisation ........................................................................................................... 22
+    B.
+    Teaching ........................................................................................................................ 23
+    C.
+    Research ........................................................................................................................ 25
+    D.
+    Disabilities ..................................................................................................................... 25
+    E.
+    Text and data mining ..................................................................................................... 27
+    F.
+    User-generated content .................................................................................................. 28
+    IV. Private copying and reprography .............................................................................. 31
+    V.
+    Fair remuneration of authors and performers ......................................................... 33
+    VI. Respect for rights ........................................................................................................ 34
+    VII. A single EU Copyright Title ....................................................................................... 36
+    VIII. Other issues .................................................................................................................. 36
+    
+    1
+    
+    I.
+    A.
+    
+    Introduction
+    Context of the consultation
+    
+    Over the last two decades, digital technology and the Internet have reshaped the ways in
+    which content is created, distributed, and accessed. New opportunities have materialised for
+    those that create and produce content (e.g. a film, a novel, a song), for new and existing
+    distribution platforms, for institutions such as libraries, for activities such as research and for
+    citizens who now expect to be able to access content – for information, education or
+    entertainment purposes – regardless of geographical borders.
+    This new environment also presents challenges. One of them is for the market to continue to
+    adapt to new forms of distribution and use. Another one is for the legislator to ensure that the
+    system of rights, limitations to rights and enforcement remains appropriate and is adapted to
+    the new environment. This consultation focuses on the second of these challenges: ensuring
+    that the EU copyright regulatory framework stays fit for purpose in the digital environment to
+    support creation and innovation, tap the full potential of the Single Market, foster growth and
+    investment in our economy and promote cultural diversity.
+    In its "Communication on Content in the Digital Single Market"1 the Commission set out two
+    parallel tracks of action: on the one hand, to complete its on-going effort to review and to
+    modernise the EU copyright legislative framework23 with a view to a decision in 2014 on
+    whether to table legislative reform proposals, and on the other, to facilitate practical industryled solutions through the stakeholder dialogue "Licences for Europe" on issues on which rapid
+    progress was deemed necessary and possible.
+    The "Licences for Europe" process has been finalised now4. The Commission welcomes the
+    practical solutions stakeholders have put forward in this context and will monitor their
+    progress. Pledges have been made by stakeholders in all four Working Groups (cross border
+    portability of services, user-generated content, audiovisual and film heritage and text and data
+    mining). Taken together, the Commission expects these pledges to be a further step in making
+    the user environment easier in many different situations. The Commission also takes note of
+    the fact that two groups – user-generated content and text and data mining – did not reach
+    consensus among participating stakeholders on either the problems to be addressed or on the
+    results. The discussions and results of "Licences for Europe" will be also taken into account in
+    the context of the review of the legislative framework.
+    As part of the review process, the Commission is now launching a public consultation on
+    issues identified in the Communication on Content in the Digital Single Market, i.e.:
+    "territoriality in the Internal Market, harmonisation, limitations and exceptions to copyright
+    in the digital age; fragmentation of the EU copyright market; and how to improve the
+    effectiveness and efficiency of enforcement while underpinning its legitimacy in the wider
+    context of copyright reform". As highlighted in the October 2013 European Council
+    
+    1
+    
+    COM (2012)789 final, 18/12/2012.
+    As announced in the Intellectual Property Strategy ' A single market for Intellectual Property Rights: COM
+    (2011)287 final, 24/05/2011.
+    3
+    "Based on market studies and impact assessment and legal drafting work" as announced in the Communication
+    (2012)789.
+    4
+    See the document “Licences for Europe – tem pledges to bring more content online”:
+    http://ec.europa.eu/internal_market/copyright/docs/licences-for-europe/131113_ten-pledges_en.pdf .
+    2
+    
+    2
+    
+    Conclusions5 "Providing digital services and content across the single market requires the
+    establishment of a copyright regime for the digital age. The Commission will therefore
+    complete its on-going review of the EU copyright framework in spring 2014. It is important to
+    modernise Europe's copyright regime and facilitate licensing, while ensuring a high level
+    protection of intellectual property rights and taking into account cultural diversity".
+    This consultation builds on previous consultations and public hearings, in particular those on
+    the "Green Paper on copyright in the knowledge economy"6, the "Green Paper on the online
+    distribution of audiovisual works"7 and "Content Online"8. These consultations provided
+    valuable feedback from stakeholders on a number of questions, on issues as diverse as the
+    territoriality of copyright and possible ways to overcome territoriality, exceptions related to
+    the online dissemination of knowledge, and rightholders’ remuneration, particularly in the
+    audiovisual sector. Views were expressed by stakeholders representing all stages in the value
+    chain, including right holders, distributors, consumers, and academics. The questions elicited
+    widely diverging views on the best way to proceed. The "Green Paper on Copyright in the
+    Knowledge Economy" was followed up by a Communication. The replies to the "Green Paper
+    on the online distribution of audiovisual works" have fed into subsequent discussions on the
+    Collective Rights Management Directive and into the current review process.
+    
+    B.
+    
+    How to submit replies to this questionnaire
+    
+    You are kindly asked to send your replies by 5 February 2014 in a MS Word, PDF or
+    OpenDocument format to the following e-mail address of DG Internal Market and Services:
+    markt-copyright-consultation@ec.europa.eu. Please note that replies sent after that date
+    will not be taken into account.
+    This consultation is addressed to different categories of stakeholders. To the extent possible,
+    the questions indicate the category/ies of respondents most likely to be concerned by them
+    (annotation in brackets, before the actual question). Respondents should nevertheless feel free
+    to reply to any/all of the questions. Also, please note that, apart from the question concerning
+    the identification of the respondent, none of the questions is obligatory. Replies containing
+    answers only to part of the questions will be also accepted.
+    You are requested to provide your answers directly within this consultation document. For the
+    “Yes/No/No opinion” questions please put the selected answer in bold and underline it so it is
+    easy for us to see your selection.
+    In your answers to the questions, you are invited to refer to the situation in EU Member
+    States. You are also invited in particular to indicate, where relevant, what would be the
+    impact of options you put forward in terms of costs, opportunities and revenues.
+    The public consultation is available in English. Responses may, however, be sent in any of the
+    24 official languages of the EU.
+    
+    C.
+    
+    Confidentiality
+    
+    The contributions received in this round of consultation as well as a summary report
+    presenting the responses in a statistical and aggregated form will be published on the website
+    of DG MARKT.
+    5
+    
+    EUCO 169/13, 24/25 October 2013.
+    COM(2008) 466/3, http://ec.europa.eu/internal_market/copyright/copyrightinfso/index_en.htm#maincontentSec2.
+    7
+    COM(2011) 427 final, http://ec.europa.eu/internal_market/consultations/2011/audiovisual_en.htm.
+    8
+    http://ec.europa.eu/internal_market/consultations/2009/content_online_en.htm.
+    6
+    
+    3
+    
+    Please note that all contributions received will be published together with the identity of the
+    contributor, unless the contributor objects to the publication of their personal data on the
+    grounds that such publication would harm his or her legitimate interests. In this case, the
+    contribution will be published in anonymous form upon the contributor's explicit request.
+    Otherwise the contribution will not be published nor will its content be reflected in the
+    summary report.
+    Please read our Privacy statement.
+    
+    4
+600  
+600  PLEASE IDENTIFY YOURSELF:
+600  Name:
+    …………………………………………………………………………………………………..
+    …………………………………………………………………………………………………..
+    In the interests of transparency, organisations (including, for example, NGOs, trade
+    associations and commercial enterprises) are invited to provide the public with relevant
+    information about themselves by registering in the Interest Representative Register and
+    subscribing to its Code of Conduct.
+    
+    
+601 If you are a Registered organisation, please indicate your Register ID number below.
+601 Your contribution will then be considered as representing the views of your
+601 organisation.
+    
+    …………………………………………………………………………………………………..
+    …………………………………………………………………………………………………..
+    
+    
+602 If your organisation is not registered, you have the opportunity to register now.
+602 Responses from organisations not registered will be published separately.
+602 
+602 If you would like to submit your reply on an anonymous basis please indicate it below by
+602 underlining the following answer:
+602 
+602 
+602 Yes, I would like to submit my reply on an anonymous basis
+602 
+602 5
+602 
+602 TYPE OF RESPONDENT (Please underline the appropriate):
+602  End user/consumer (e.g. internet user, reader, subscriber to music or audiovisual
+602 service, researcher, student) OR Representative of end users/consumers
+602  for the purposes of this questionnaire normally referred to in questions as "end
+602 users/consumers"
+602  Institutional user (e.g. school, university, research centre, library, archive)
+602 Representative of institutional users
+602 
+602 OR
+602 
+602  for the purposes of this questionnaire normally referred to in questions as
+602 "institutional users"
+602  Author/Performer OR Representative of authors/performers
+602  Publisher/Producer/Broadcaster
+602 publishers/producers/broadcasters
+602 
+602 OR
+602 
+602 Representative
+602 
+602 of
+602 
+602  the two above categories are, for the purposes of this questionnaire, normally
+602 referred to in questions as "right holders"
+602  Intermediary/Distributor/Other service provider (e.g. online music or audiovisual
+602 service, games platform, social media, search engine, ICT industry) OR
+602 Representative of intermediaries/distributors/other service providers
+602  for the purposes of this questionnaire normally referred to in questions as "service
+602 providers"
+602  Collective Management Organisation
+602  Public authority
+602  Member State
+602  Other (Please explain):
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    6
+    
+    II.
+    
+    Rights and the functioning of the Single Market
+    
+    A.
+    Why is it not possible to access many online content services from
+    anywhere in Europe?
+    [The territorial scope of the rights involved in digital transmissions and the
+    segmentation of the market through licensing agreements]
+    Holders of copyright and related rights – e.g. writers, singers, musicians - do not enjoy
+    a single protection in the EU. Instead, they are protected on the basis of a bundle of national
+    rights in each Member State. Those rights have been largely harmonised by the existing EU
+    Directives. However, differences remain and the geographical scope of the rights is limited to
+    the territory of the Member State granting them. Copyright is thus territorial in the sense that
+    rights are acquired and enforced on a country-by-country basis under national law9.
+    The dissemination of copyright-protected content on the Internet – e.g. by a music streaming
+    service, or by an online e-book seller – therefore requires, in principle, an authorisation for
+    each national territory in which the content is communicated to the public. Rightholders are,
+    of course, in a position to grant a multi-territorial or pan-European licence, such that content
+    services can be provided in several Member States and across borders. A number of steps
+    have been taken at EU level to facilitate multi-territorial licences: the proposal for a Directive
+    on Collective Rights Management10 should significantly facilitate the delivery of multiterritorial licences in musical works for online services11; the structured stakeholder dialogue
+    “Licences for Europe”12 and market-led developments such as the on-going work in the
+    Linked Content Coalition13.
+    "Licences for Europe" addressed in particular the specific issue of cross-border portability, i.e.
+    the ability of consumers having subscribed to online services in their Member State to keep
+    accessing them when travelling temporarily to other Member States. As a result,
+    representatives of the audio-visual sector issued a joint statement affirming their commitment
+    to continue working towards the further development of cross-border portability14.
+    Despite progress, there are continued problems with the cross-border provision of, and access
+    to, services. These problems are most obvious to consumers wanting to access services that
+    are made available in Member States other than the one in which they live. Not all online
+    services are available in all Member States and consumers face problems when trying
+    to access such services across borders. In some instances, even if the “same” service is
+    available in all Member States, consumers cannot access the service across borders (they can
+    only access their “national” service, and if they try to access the "same" service in another
+    Member State they are redirected to the one designated for their country of residence).
+    9
+    
+    This principle has been confirmed by the Court of justice on several occasions.
+    Proposal for a Directive of the European Parliament and of the Council of 11 July 2012 on collective
+    management of copyright and related rights and multi-territorial licensing of rights in musical works for online
+    uses in the internal market, COM(2012) 372 final.
+    11
+    Collective Management Organisations play a significant role in the management of online rights for musical
+    works in contrast to the situation where online rights are licensed directly by right holders such as film or record
+    producers or by newspaper or book publishers.
+    12
+    You can find more information on the following website: http://ec.europa.eu/licences-for-europe-dialogue/.
+    13
+    You can find more information on the following website: http://www.linkedcontentcoalition.org/.
+    14
+    See the document “Licences for Europe – tem pledges to bring more content online”:
+    http://ec.europa.eu/internal_market/copyright/docs/licences-for-europe/131113_ten-pledges_en.pdf .
+    10
+    
+    7
+    
+    This situation may in part stem from the territoriality of rights and difficulties associated with
+    the clearing of rights in different territories. Contractual clauses in licensing agreements
+    between right holders and distributors and/or between distributors and end users may also be
+    at the origin of some of the problems (denial of access, redirection).
+    The main issue at stake here is, therefore, whether further measures (legislative or nonlegislative, including market-led solutions) need to be taken at EU level in the medium term15
+    to increase the cross-border availability of content services in the Single Market, while
+    ensuring an adequate level of protection for right holders.
+001 1.
+001 [In particular if you are an end user/consumer:] Have you faced problems when
+001 trying to access online services in an EU Member State other than the one in which you
+001 live?
+    YES - Please provide examples indicating the Member State, the sector and the type of
+    content concerned (e.g. premium content such as certain films and TV series, audio-visual
+    content in general, music, e-books, magazines, journals and newspapers, games, applications
+    and other software)
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+002 2.
+002 [In particular if you are a service provider:] Have you faced problems when seeking
+002 to provide online services across borders in the EU?
+    YES - Please explain whether such problems, in your experience, are related to copyright
+    or to other issues (e.g. business decisions relating to the cost of providing services across
+    borders, compliance with other laws such as consumer protection)? Please provide examples
+    indicating the Member State, the sector and the type of content concerned (e.g. premium
+    content such as certain films and TV series, audio-visual content in general, music, e-books,
+    magazines, journals and newspapers, games, applications and other software).
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+003 3.
+003 [In particular if you are a right holder or a collective management organisation:]
+003 How often are you asked to grant multi-territorial licences? Please indicate, if possible, the
+003 number of requests per year and provide examples indicating the Member State, the sector
+003 and the type of content concerned.
+    [Open question]
+    ……………………………………………………………………………………………….
+    15
+    
+    For possible long term measures such as the establishment of a European Copyright Code (establishing
+    a single title) see section VII of this consultation document.
+    
+    8
+    
+    ……………………………………………………………………………………………….
+004 4.
+004 If you have identified problems in the answers to any of the questions above – what
+004 would be the best way to tackle them?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+005 5.
+005 [In particular if you are a right holder or a collective management organisation:] Are
+005 there reasons why, even in cases where you hold all the necessary rights for all the
+005 territories in question, you would still find it necessary or justified to impose territorial
+005 restrictions on a service provider (in order, for instance, to ensure that access to certain
+005 content is not possible in certain European countries)?
+    YES – Please explain by giving examples
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+006 6.
+006 [In particular if you are e.g. a broadcaster or a service provider:] Are there reasons
+006 why, even in cases where you have acquired all the necessary rights for all the territories in
+006 question, you would still find it necessary or justified to impose territorial restrictions on
+006 the service recipient (in order for instance, to redirect the consumer to a different website
+006 than the one he is trying to access)?
+    – Please explain by giving examples
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+007 7.
+007 Do you think that further measures (legislative or non-legislative, including marketled solutions) are needed at EU level to increase the cross-border availability of content
+007 services in the Single Market, while ensuring an adequate level of protection for right
+007 holders?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    9
+    
+    ……………………………………………………………………………………………….
+    NO OPINION
+    
+    B.
+    Is there a need for more clarity as regards the scope of what needs to be
+    authorised (or not) in digital transmissions?
+    [The definition of the rights involved in digital transmissions]
+    The EU framework for the protection of copyright and related rights in the digital
+    environment is largely established by Directive 2001/29/EC16 on the harmonisation of certain
+    aspects of copyright and related rights in the information society. Other EU directives in this
+    field that are relevant in the online environment are those relating to the protection of
+    software17 and databases18.
+    Directive 2001/29/EC harmonises the rights of authors and neighbouring rightholders19 which
+    are essential for the transmission of digital copies of works (e.g. an e-book) and other
+    protected subject matter (e.g. a record in a MP3 format) over the internet or similar digital
+    networks.
+    The most relevant rights for digital transmissions are the reproduction right, i.e. the right to
+    authorise or prohibit the making of copies20, (notably relevant at the start of the transmission –
+    e.g. the uploading of a digital copy of a work to a server in view of making it available – and
+    at the users’ end – e.g. when a user downloads a digital copy of a work) and the
+    communication to the public/making available right, i.e. the rights to authorise or prohibit the
+    dissemination of the works in digital networks21. These rights are intrinsically linked in digital
+    transmissions and both need to be cleared.
+    1.
+    
+    The act of “making available”
+    
+    Directive 2001/29/EC specifies neither what is covered by the making available right (e.g. the
+    upload, the accessibility by the public, the actual reception by the public) nor where the act of
+    “making available” takes place. This does not raise questions if the act is limited to a single
+    territory. Questions arise however when the transmission covers several territories and rights
+    need to be cleared (does the act of "making available" happen in the country of the upload
+    only? in each of the countries where the content is potentially accessible? in each of the
+    countries where the content is effectively accessed?). The most recent case law of the Court of
+    Justice of the European Union (CJEU) suggests that a relevant criterion is the “targeting” of
+    
+    16
+    
+    Directive 2001/29/EC of the European Parliament and of the Council of 22 May 2001 on the harmonisation of
+    certain aspects of copyright and related rights in the information society.
+    17
+    Directive 2009/24/EC of the European Parliament and of the Council of 23 April 2009 on the legal protection
+    of computer programs.
+    18
+    Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of
+    databases.
+    19
+    Film and record producers, performers and broadcasters are holders of so-called “neighbouring rights” in,
+    respectively, their films, records, performances and broadcast. Authors’ content protected by copyright is
+    referred to as a “work” or “works”, while content protected by neighbouring rights is referred to as “other subject
+    matter”.
+    20
+    The right to “authorise or prohibit direct or indirect, temporary or permanent reproduction by any means and
+    in any form, in whole or in part” (see Art. 2 of Directive 2001/29/EC) although temporary acts of reproduction of
+    a transient or incidental nature are, under certain conditions, excluded (see art. 5(1) of Directive 2001/29/EC).
+    21
+    The right to authorise or prohibit any communication to the public by wire or wireless means and to authorise
+    or prohibit the making available to the public “on demand” (see Art. 3 of Directive 2001/29/EC).
+    
+    10
+    
+    a certain Member State's public22. According to this approach the copyright-relevant act
+    (which has to be licensed) occurs at least in those countries which are “targeted” by the online
+    service provider. A service provider “targets” a group of customers residing in a specific
+    country when it directs its activity to that group, e.g. via advertisement, promotions,
+    a language or a currency specifically targeted at that group.
+008 8.
+008 Is the scope of the “making available” right in cross-border situations – i.e. when
+008 content is disseminated across borders – sufficiently clear?
+    YES
+    NO – Please explain how this could be clarified and what type of clarification would be
+    required (e.g. as in "targeting" approach explained above, as in "country of origin"
+    approach23)
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+009 9.
+009 [In particular if you are a right holder:] Could a clarification of the territorial scope
+009 of the “making available” right have an effect on the recognition of your rights (e.g.
+009 whether you are considered to be an author or not, whether you are considered to have
+009 transferred your rights or not), on your remuneration, or on the enforcement of rights
+009 (including the availability of injunctive relief24)?
+    YES – Please explain how such potential effects could be addressed
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+    2.
+    
+    Two rights involved in a single act of exploitation
+    
+    Each act of transmission in digital networks entails (in the current state of technology and
+    law) several reproductions. This means that there are two rights that apply to digital
+    transmissions: the reproduction right and the making available right. This may complicate the
+    licensing of works for online use notably when the two rights are held by different
+    persons/entities.
+    
+    22
+    
+    See in particular Case C-173/11 (Football Dataco vs Sportradar) and Case C-5/11 (Donner) for copyright and
+    related rights, and Case C-324/09 (L’Oréal vs eBay) for trademarks. With regard to jurisdiction see also joined
+    Cases C-585/08 and C-144/09 (Pammer and Hotel Alpenhof) and pending CaseC-441/13 (Pez Hejduk); see
+    however, adopting a different approach, Case C-170/12 (Pinckney vs KDG Mediatech).
+    23
+    The objective of implementing a “country of origin” approach is to localise the copyright relevant act that
+    must be licenced in a single Member State (the "country of origin", which could be for example the Member
+    State in which the content is uploaded or where the service provider is established), regardless of in how many
+    Member States the work can be accessed or received. Such an approach has already been introduced at EU level
+    with regard to broadcasting by satellite (see Directive 93/83/EEC on the coordination of certain rules concerning
+    copyright and rights related to copyright applicable to satellite broadcasting and cable retransmission).
+    24
+    Injunctive relief is a temporary or permanent remedy allowing the right holder to stop or prevent
+    an infringement of his/her right.
+    
+    11
+    
+010 10.
+010 [In particular if you a service provider or a right holder:] Does the application of two
+010 rights to a single act of economic exploitation in the online environment (e.g. a download)
+010 create problems for you?
+    YES – Please explain what type of measures would be needed in order to address such
+    problems (e.g. facilitation of joint licences when the rights are in different hands, legislation
+    to achieve the "bundling of rights")
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+    3.
+    
+    Linking and browsing
+    
+    Hyperlinks are references to data that lead a user from one location in the Internet to another.
+    They are indispensable for the functioning of the Internet as a network. Several cases are
+    pending before the CJEU25 in which the question has been raised whether the provision of
+    a clickable link constitutes an act of communication to the public/making available to the
+    public subject to the authorisation of the rightholder.
+    A user browsing the internet (e.g. viewing a web-page) regularly creates temporary copies of
+    works and other subject-matter protected under copyright on the screen and in the 'cache'
+    memory of his computer. A question has been referred to the CJEU26 as to whether such
+    copies are always covered by the mandatory exception for temporary acts of reproduction
+    provided for in Article 5(1) of Directive 2001/29/EC.
+011 11.
+011 Should the provision of a hyperlink leading to a work or other subject matter
+011 protected under copyright, either in general or under specific circumstances, be subject to
+011 the authorisation of the rightholder?
+    YES – Please explain whether you consider this to be the case in general, or under specific
+    circumstances, and why
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain whether you consider this to be the case in general, or under specific
+    circumstances, and why (e.g. because it does not amount to an act of communication to the
+    public – or to a new public, or because it should be covered by a copyright exception)
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+    
+    25
+    
+    Cases C-466/12 (Svensson), C-348/13 (Bestwater International) and C-279/13 (C More entertainment).
+    Case C-360/13 (Public Relations Consultants Association Ltd). See also
+    http://www.supremecourt.gov.uk/decided-cases/docs/UKSC_2011_0202_PressSummary.pdf.
+    26
+    
+    12
+    
+012 12.
+012 Should the viewing of a web-page where this implies the temporary reproduction of
+012 a work or other subject matter protected under copyright on the screen and in the cache
+012 memory of the user’s computer, either in general or under specific circumstances, be
+012 subject to the authorisation of the rightholder?
+    YES – Please explain whether you consider this to be the case in general, or under specific
+    circumstances, and why
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain whether you consider this to be the case in general, or under specific
+    circumstances, and why (e.g. because it is or should be covered by a copyright exception)
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+    4.
+    
+    Download to own digital content
+    
+    Digital content is increasingly being bought via digital transmission (e.g. download to own).
+    Questions arise as to the possibility for users to dispose of the files they buy in this manner
+    (e.g. by selling them or by giving them as a gift). The principle of EU exhaustion of the
+    distribution right applies in the case of the distribution of physical copies (e.g. when a tangible
+    article such as a CD or a book, etc. is sold, the right holder cannot prevent the further
+    distribution of that tangible article)27. The issue that arises here is whether this principle can
+    also be applied in the case of an act of transmission equivalent in its effect to distribution
+    (i.e. where the buyer acquires the property of the copy)28. This raises difficult questions,
+    notably relating to the practical application of such an approach (how to avoid re-sellers
+    keeping and using a copy of a work after they have “re-sold” it – this is often referred to as
+    the “forward and delete” question) as well as to the economic implications of the creation of
+    a second-hand market of copies of perfect quality that never deteriorate (in contrast to the
+    second-hand market for physical goods).
+013 13.
+013 [In particular if you are an end user/consumer:] Have you faced restrictions when
+013 trying to resell digital files that you have purchased (e.g. mp3 file, e-book)?
+    YES – Please explain by giving examples
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+    27
+    
+    See also recital 28 of Directive 2001/29/EC.
+    In Case C-128/11 (Oracle vs. UsedSoft) the CJEU ruled that an author cannot oppose the resale of a secondhand licence that allows downloading his computer program from his website and using it for an unlimited
+    period of time. The exclusive right of distribution of a copy of a computer program covered by such a licence is
+    exhausted on its first sale. While it is thus admitted that the distribution right may be subject to exhaustion in
+    case of computer programs offered for download with the right holder’s consent, the Court was careful to
+    emphasise that it reached this decision based on the Computer Programs Directive. It was stressed that this
+    exhaustion rule constituted a lex specialis in relation to the Information Society Directive (UsedSoft, par. 51,
+    56).
+    28
+    
+    13
+    
+014 14.
+014 [In particular if you are a right holder or a service provider:] What would be the
+014 consequences of providing a legal framework enabling the resale of previously purchased
+014 digital content? Please specify per market (type of content) concerned.
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    C.
+    
+    Registration of works and other subject matter – is it a good idea?
+    
+    Registration is not often discussed in copyright in the EU as the existing international treaties
+    in the area prohibit formalities as a condition for the protection and exercise of rights.
+    However, this prohibition is not absolute29. Moreover a system of registration does not need
+    to be made compulsory or constitute a precondition for the protection and exercise of rights.
+    With a longer term of protection and with the increased opportunities that digital technology
+    provides for the use of content (including older works and works that otherwise would not
+    have been disseminated), the advantages and disadvantages of a system of registration are
+    increasingly being considered30.
+015 15.
+015 Would the creation of a registration system at EU level help in the identification and
+015 licensing of works and other subject matter?
+    YES
+    NO
+    NO OPINION
+016 16.
+016 
+016 What would be the possible advantages of such a system?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+017 17.
+017 
+017 What would be the possible disadvantages of such a system?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+018 18.
+018 
+018 What incentives for registration by rightholders could be envisaged?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    29
+    
+    For example, it does not affect “domestic” works – i.e. works originating in the country imposing the
+    formalities as opposed to works originating in another country.
+    30
+    On the basis of Article 3.6 of the Directive 2012/28/EU of the European Parliament and of the Council of 25
+    October 2012 on certain permitted uses of orphan works, a publicly accessible online database is currently being
+    set up by the Office for Harmonisation of the Internal Market (OHIM) for the registration of orphan works.
+    
+    14
+    
+    ……………………………………………………………………………………………….
+    
+    D.
+    
+    How to improve the use and interoperability of identifiers
+    
+    There are many private databases of works and other subject matter held by producers,
+    collective management organisations, and institutions such as libraries, which are based to
+    a greater or lesser extent on the use of (more or less) interoperable, internationally agreed
+    ‘identifiers’. Identifiers can be compared to a reference number embedded in a work, are
+    specific to the sector in which they have been developed31, and identify, variously, the work
+    itself, the owner or the contributor to a work or other subject matter. There are notable
+    examples of where industry is undertaking actions to improve the interoperability of such
+    identifiers and databases. The Global Repertoire Database32 should, once operational, provide
+    a single source of information on the ownership and control of musical works worldwide. The
+    Linked Content Coalition33 was established to develop building blocks for the expression and
+    management of rights and licensing across all content and media types. It includes the
+    development of a Rights Reference Model (RRM) – a comprehensive data model for all types
+    of rights in all types of content. The UK Copyright Hub34 is seeking to take such identification
+    systems a step further, and to create a linked platform, enabling automated licensing across
+    different sectors.
+019 19.
+019 What should be the role of the EU in promoting the adoption of identifiers in the
+019 content sector, and in promoting the development and interoperability of rights ownership
+019 and permissions databases?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    E.
+    
+    Term of protection – is it appropriate?
+    
+    Works and other subject matter are protected under copyright for a limited period of time.
+    After the term of protection has expired, a work falls into the public domain and can be freely
+    used by anyone (in accordance with the applicable national rules on moral rights). The Berne
+    Convention35 requires a minimum term of protection of 50 years after the death of the author.
+    The EU rules extend this term of protection to 70 years after the death of the author (as do
+    many other countries, e.g. the US).
+    With regard to performers in the music sector and phonogram producers, the term provided
+    for in the EU rules also extend 20 years beyond what is mandated in international agreements,
+    providing for a term of protection of 70 years after the first publication. Performers and
+    producers in the audio-visual sector, however, do not benefit from such an extended term of
+    protection.
+    
+    31
+    
+    E.g. the International Standard Recording Code (ISRC) is used to identify recordings, the International
+    Standard Book Number (ISBN) is used to identify books.
+    32
+    You will find more information about this initiative on the following website:
+    http://www.globalrepertoiredatabase.com/.
+    33
+    You will find more information about this initiative (funded in part by the European Commission) on the
+    following website: www.linkedcontentcoalition.org.
+    34
+    You will find more information about this initiative on the following website: http://www.copyrighthub.co.uk/.
+    35
+    Berne Convention for the Protection of Literary and Artistic Works, http://www.wipo.int/treaties/en/ip/berne/.
+    
+    15
+    
+020 20.
+020 Are the current terms of copyright protection still appropriate in the digital
+020 environment?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain if they should be longer or shorter
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+    
+    III.
+    
+    Limitations and exceptions in the Single Market
+    
+    Limitations and exceptions to copyright and related rights enable the use of works and other
+    protected subject-matter, without obtaining authorisation from the rightholders, for certain
+    purposes and to a certain extent (for instance the use for illustration purposes of an extract
+    from a novel by a teacher in a literature class). At EU level they are established in a number
+    of copyright directives, most notably Directive 2001/29/EC36.
+    Exceptions and limitations in the national and EU copyright laws have to respect international
+    law37. In accordance with international obligations, the EU acquis requires that limitations and
+    exceptions can only be applied in certain special cases which do not conflict with a normal
+    exploitation of the work or other subject matter and do not unreasonably prejudice the
+    legitimate interest of the rightholders.
+    Whereas the catalogue of limitations and exceptions included in EU law is exhaustive (no
+    other exceptions can be applied to the rights harmonised at EU level)38, these limitations and
+    exceptions are often optional39, in the sense that Member States are free to reflect in national
+    legislation as many or as few of them as they wish. Moreover, the formulation of certain of
+    the limitations and exceptions is general enough to give significant flexibility to the Member
+    States as to how, and to what extent, to implement them (if they decide to do so). Finally, it is
+    worth noting that not all of the limitations and exceptions included in the EU legal framework
+    for copyright are of equivalent significance in policy terms and in terms of their potential
+    effect on the functioning of the Single Market.
+    In addition, in the same manner that the definition of the rights is territorial (i.e. has an effect
+    only within the territory of the Member State), the definition of the limitations and exceptions
+    to the rights is territorial too (so an act that is covered by an exception in a Member State "A"
+    
+    36
+    
+    Plus Directive 96/9/EC on the legal protection of databases; Directive 2009/24/EC on the legal protection of
+    computer programs, and Directive 92/100/EC on rental right and lending right.
+    37
+    Article 9(2) of the Berne Convention for the Protection of Literary and Artistic Works (1971); Article 13 of
+    the TRIPS Agreement (Trade Related Intellectual Property Rights) 1994; Article 16(2) of the WIPO Performers
+    and Phonograms Treaty (1996); Article 9(2) of the WIPO Copyright Treaty (1996).
+    38
+    Other than the grandfathering of the exceptions of minor importance for analogue uses existing in Member
+    States at the time of adoption of Directive 2001/29/EC (see, Art. 5(3)(o)).
+    39
+    With the exception of certain limitations: (i) in the Computer Programs Directive, (ii) in the Database
+    Directive, (iii) Article 5(1) in the Directive 2001/29/EC and (iv) the Orphan Works Directive.
+    
+    16
+    
+    may still require the authorisation of the rightholder once we move to the Member
+    State "B")40.
+    The cross-border effect of limitations and exceptions also raises the question of fair
+    compensation of rightholders. In some instances, Member States are obliged to compensate
+    rightholders for the harm inflicted on them by a limitation or exception to their rights. In other
+    instances Member States are not obliged, but may decide, to provide for such compensation.
+    If a limitation or exception triggering a mechanism of fair compensation were to be given
+    cross-border effect (e.g. the books are used for illustration in an online course given by an
+    university in a Member State "A" and the students are in a Member State "B") then there
+    would also be a need to clarify which national law should determine the level of that
+    compensation and who should pay it.
+    Finally, the question of flexibility and adaptability is being raised: what is the best mechanism
+    to ensure that the EU and Member States’ regulatory frameworks adapt when necessary
+    (either to clarify that certain uses are covered by an exception or to confirm that for certain
+    uses the authorisation of rightholders is required)? The main question here is whether
+    a greater degree of flexibility can be introduced in the EU and Member States regulatory
+    framework while ensuring the required legal certainty, including for the functioning of the
+    Single Market, and respecting the EU's international obligations.
+021 21.
+021 Are there problems arising from the fact that most limitations and exceptions
+021 provided in the EU copyright directives are optional for the Member States?
+    YES – Please explain by referring to specific cases
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+022 22.
+022 Should some/all of the exceptions be made mandatory and, if so, is there a need for
+022 a higher level of harmonisation of such exceptions?
+    YES – Please explain by referring to specific cases
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+    40
+    
+    Only the exception established in the recent Orphan Works Directive (a mandatory exception to copyright and
+    related rights in the case where the rightholders are not known or cannot be located) has been given a crossborder effect, which means that, for instance, once a literary work – for instance a novel – is considered an
+    orphan work in a Member State, that same novel shall be considered an orphan work in all Member States and
+    can be used and accessed in all Member States.
+    
+    17
+    
+023 23.
+023 Should any new limitations and exceptions be added to or removed from the existing
+023 catalogue? Please explain by referring to specific cases.
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+024 24. Independently from the questions above, is there a need to provide for a greater
+024 degree of flexibility in the EU regulatory framework for limitations and exceptions?
+    YES – Please explain why
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain why
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+025 25.
+025 If yes, what would be the best approach to provide for flexibility? (e.g. interpretation
+025 by national courts and the ECJ, periodic revisions of the directives, interpretations by the
+025 Commission, built-in flexibility, e.g. in the form of a fair-use or fair dealing provision /
+025 open norm, etc.)? Please explain indicating what would be the relative advantages and
+025 disadvantages of such an approach as well as its possible effects on the functioning of the
+025 Internal Market.
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+026 26.
+026 Does the territoriality of limitations and exceptions, in your experience, constitute
+026 a problem?
+    YES – Please explain why and specify which exceptions you are referring to
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain why and specify which exceptions you are referring to
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+    
+    18
+    
+027 27.
+027 In the event that limitations and exceptions established at national level were to
+027 have cross-border effect, how should the question of “fair compensation” be addressed,
+027 when such compensation is part of the exception? (e.g. who pays whom, where?)
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    A.
+    
+    Access to content in libraries and archives
+    
+    Directive 2001/29/EC enables Member States to reflect in their national law a range of
+    limitations and exceptions for the benefit of publicly accessible libraries, educational
+    establishments and museums, as well as archives. If implemented, these exceptions allow acts
+    of preservation and archiving41 and enable on-site consultation of the works and other subject
+    matter in the collections of such institutions42. The public lending (under an exception or
+    limitation) by these establishments of physical copies of works and other subject matter is
+    governed by the Rental and Lending Directive43.
+    Questions arise as to whether the current framework continues to achieve the objectives
+    envisaged or whether it needs to be clarified or updated to cover use in digital networks. At
+    the same time, questions arise as to the effect of such a possible expansion on the normal
+    exploitation of works and other subject matter and as to the prejudice this may cause to
+    rightholders. The role of licensing and possible framework agreements between different
+    stakeholders also needs to be considered here.
+    1.
+    
+    Preservation and archiving
+    
+    The preservation of the copies of works or other subject-matter held in the collections of
+    cultural establishments (e.g. books, records, or films) – the restoration or replacement of
+    works, the copying of fragile works - may involve the creation of another copy/ies of these
+    works or other subject matter. Most Member States provide for an exception in their national
+    laws allowing for the making of such preservation copies. The scope of the exception differs
+    from Member State to Member State (as regards the type of beneficiary establishments, the
+    types of works/subject-matter covered by the exception, the mode of copying and the number
+    of reproductions that a beneficiary establishment may make). Also, the current legal status of
+    new types of preservation activities (e.g. harvesting and archiving publicly available web
+    content) is often uncertain.
+028 28.
+028 (a) [In particular if you are an institutional user:] Have you experienced specific
+028 problems when trying to use an exception to preserve and archive specific works or other
+028 subject matter in your collection?
+028 (b) [In particular if you are a right holder:] Have you experienced problems with the use by
+028 libraries, educational establishments, museum or archives of the preservation exception?
+    YES – Please explain, by Member State, sector, and the type of use in question.
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    41
+    
+    Article 5(2)c of Directive 2001/29.
+    Article 5(3)n of Directive 2001/29.
+    43
+    Article 5 of Directive 2006/115/EC.
+    42
+    
+    19
+    
+    NO
+    NO OPINION
+029 29.
+029 If there are problems, how would they best be solved?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+030 30.
+030 If your view is that a legislative solution is needed, what would be its main
+030 elements? Which activities of the beneficiary institutions should be covered and under
+    which conditions?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+031 31.
+031 
+031 If your view is that a different solution is needed, what would it be?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    2.
+    
+    Off-premises access to library collections
+    
+    Directive 2001/29/EC provides an exception for the consultation of works and other subjectmatter (consulting an e-book, watching a documentary) via dedicated terminals on the
+    premises of such establishments for the purpose of research and private study. The online
+    consultation of works and other subject-matter remotely (i.e. when the library user is not on
+    the premises of the library) requires authorisation and is generally addressed in agreements
+    between universities/libraries and publishers. Some argue that the law rather than agreements
+    should provide for the possibility to, and the conditions for, granting online access to
+    collections.
+032 32.
+032 (a) [In particular if you are an institutional user:] Have you experienced specific
+032 problems when trying to negotiate agreements with rights holders that enable you to
+032 provide remote access, including across borders, to your collections (or parts thereof) for
+032 purposes of research and private study?
+032 (b) [In particular if you are an end user/consumer:] Have you experienced specific problems
+032 when trying to consult, including across borders, works and other subject-matter held in
+032 the collections of institutions such as universities and national libraries when you are not
+032 on the premises of the institutions in question?
+032 (c) [In particular if you are a right holder:] Have you negotiated agreements with
+032 institutional users that enable those institutions to provide remote access, including across
+032 borders, to the works or other subject-matter in their collections, for purposes of research
+032 and private study?
+    [Open question]
+    20
+    
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+033 33.
+033 
+033 If there are problems, how would they best be solved?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+034 34.
+034 If your view is that a legislative solution is needed, what would be its main
+034 elements? Which activities of the beneficiary institutions should be covered and under
+034 which conditions?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+035 35.
+035 
+035 If your view is that a different solution is needed, what would it be?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    3.
+    
+    E – lending
+    
+    Traditionally, public libraries have loaned physical copies of works (i.e. books, sometimes
+    also CDs and DVDs) to their users. Recent technological developments have made it
+    technically possible for libraries to provide users with temporary access to digital content,
+    such as e-books, music or films via networks. Under the current legal framework, libraries
+    need to obtain the authorisation of the rights holders to organise such e-lending activities. In
+    various Member States, publishers and libraries are currently experimenting with different
+    business models for the making available of works online, including direct supply of e-books
+    to libraries by publishers or bundling by aggregators.
+036 36.
+036 (a) [In particular if you are a library:] Have you experienced specific problems
+036 when trying to negotiate agreements to enable the electronic lending (e-lending), including
+036 across borders, of books or other materials held in your collection?
+036 (b) [In particular if you are an end user/consumer:] Have you experienced specific problems
+036 when trying to borrow books or other materials electronically (e-lending), including across
+036 borders, from institutions such as public libraries?
+036 (c) [In particular if you are a right holder:] Have you negotiated agreements with libraries
+036 to enable them to lend books or other materials electronically, including across borders?
+    YES – Please explain with specific examples
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    21
+    
+    NO
+    NO OPINION
+037 37.
+037 If there are problems, how would they best be solved?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    The following two questions are relevant both to this point (n° 3) and the previous one (n° 2).
+038 38.
+038 [In particular if you are an institutional user:] What differences do you see in the
+038 management of physical and online collections, including providing access to your
+038 subscribers? What problems have you encountered?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+039 39.
+039 [In particular if you are a right holder:] What difference do you see between
+039 libraries’ traditional activities such as on-premises consultation or public lending and
+039 activities such as off-premises (online, at a distance) consultation and e-lending? What
+039 problems have you encountered?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    4.
+    
+    Mass digitisation
+    
+    The term “mass digitisation” is normally used to refer to efforts by institutions such as
+    libraries and archives to digitise (e.g. scan) the entire content or part of their collections with
+    an objective to preserve these collections and, normally, to make them available to the public.
+    Examples are efforts by libraries to digitise novels form the early part of the 20 th century or
+    whole collections of pictures of historical value. This matter has been partly addressed at the
+    EU level by the 2011 Memorandum of Understanding (MoU) on key principles on the
+    digitisation and making available of out of commerce works (i.e. works which are no longer
+    found in the normal channels of commerce), which is aiming to facilitate mass digitisation
+    efforts (for books and learned journals) on the basis of licence agreements between libraries
+    and similar cultural institutions on the one hand and the collecting societies representing
+    authors and publishers on the other44. Provided the required funding is ensured (digitisation
+    projects are extremely expensive), the result of this MoU should be that books that are
+    currently to be found only in the archives of, for instance, libraries will be digitised and made
+    available online to everyone. The MoU is based on voluntary licences (granted by Collective
+    Management Organisations on the basis of the mandates they receive from authors and
+    publishers). Some Member States may need to enact legislation to ensure the largest possible
+    44
+    
+    You will find more information about his MoU on
+    http://ec.europa.eu/internal_market/copyright/out-of-commerce/index_en.htm .
+    
+    the
+    
+    following
+    
+    website:
+    
+    22
+    
+    effect of such licences (e.g. by establishing in legislation a presumption of representation of
+    a collecting society or the recognition of an “extended effect” to the licences granted)45.
+040 40.
+040 [In particular if you are an institutional user, engaging or wanting to engage in mass
+040 digitisation projects, a right holder, a collective management organisation:] Would it be
+040 necessary in your country to enact legislation to ensure that the results of the 2011 MoU
+040 (i.e. the agreements concluded between libraries and collecting societies) have a crossborder effect so that out of commerce works can be accessed across the EU?
+    YES – Please explain why and how it could best be achieved
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+041 41.
+041 Would it be necessary to develop mechanisms, beyond those already agreed for
+041 other types of content (e.g. for audio- or audio-visual collections, broadcasters’ archives)?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+    
+    B.
+    
+    Teaching
+    
+    Directive 2001/29/EC46 enables Member States to implement in their national legislation
+    limitations and exceptions for the purpose of illustration for non-commercial teaching. Such
+    exceptions would typically allow a teacher to use parts of or full works to illustrate his course,
+    e.g. by distributing copies of fragments of a book or of newspaper articles in the classroom or
+    by showing protected content on a smart board without having to obtain authorisation from
+    the right holders. The open formulation of this (optional) provision allows for rather different
+    implementation at Member States level. The implementation of the exception differs from
+    Member State to Member State, with several Member States providing instead a framework
+    
+    45
+    
+    France and Germany have already adopted legislation to back the effects of the MoU. The French act (LOI n°
+    2012-287 du 1er mars 2012 relative à l'exploitation numérique des livres indisponibles du xxe siècle) foresees
+    collective management, unless the author or publisher in question opposes such management. The German act
+    (Gesetz zur Nutzung verwaister und vergriffener Werke und einer weiteren Änderung des Urheberrechtsgesetzes
+    vom 1. Oktober 2013) contains a legal presumption of representation by a collecting society in relation to works
+    whose rightholders are not members of the collecting society.
+    46
+    Article 5(3)a of Directive 2001/29.
+    
+    23
+    
+    for the licensing of content for certain educational uses. Some argue that the law should
+    provide for better possibilities for distance learning and study at home.
+042 42.
+042 (a) [In particular if you are an end user/consumer or an institutional user:] Have you
+042 experienced specific problems when trying to use works or other subject-matter for
+042 illustration for teaching, including across borders?
+042 (b) [In particular if you are a right holder:] Have you experienced specific problems
+042 resulting from the way in which works or other subject-matter are used for illustration for
+042 teaching, including across borders?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+043 43.
+043 
+043 If there are problems, how would they best be solved?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+044 44.
+044 What mechanisms exist in the market place to facilitate the use of content for
+044 illustration for teaching purposes? How successful are they?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+045 45.
+045 If your view is that a legislative solution is needed, what would be its main
+045 elements? Which activities of the beneficiary institutions should be covered and under what
+045 conditions?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+046 46.
+046 
+046 If your view is that a different solution is needed, what would it be?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    24
+    
+    C.
+    
+    Research
+    
+    Directive 2001/29/EC47 enables Member States to choose whether to implement in their
+    national laws a limitation for the purpose of non-commercial scientific research. The open
+    formulation of this (optional) provision allows for rather different implementations at Member
+    States level.
+047 47.
+047 (a) [In particular if you are an end user/consumer or an institutional user:] Have you
+047 experienced specific problems when trying to use works or other subject matter in the
+047 context of research projects/activities, including across borders?
+047 (b) [In particular if you are a right holder:] Have you experienced specific problems
+047 resulting from the way in which works or other subject-matter are used in the context of
+047 research projects/activities, including across borders?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+048 48.
+048 
+048 If there are problems, how would they best be solved?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+049 49.
+049 What mechanisms exist in the Member States to facilitate the use of content for
+049 research purposes? How successful are they?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    D.
+    
+    Disabilities
+    
+    Directive 2001/29/EC48 provides for an exception/limitation for the benefit of people with
+    a disability. The open formulation of this (optional) provision allows for rather different
+    implementations at Member States level. At EU and international level projects have been
+    launched to increase the accessibility of works and other subject-matter for persons with
+    disabilities (notably by increasing the number of works published in special formats and
+    facilitating their distribution across the European Union) 49.
+    47
+    
+    Article 5(3)a of Directive 2001/29.
+    Article 5 (3)b of Directive 2001/29.
+    49
+    The European Trusted Intermediaries Network (ETIN) resulting from a Memorandum of Understanding
+    between representatives of the right-holder community (publishers, authors, collecting societies) and interested
+    parties
+    such
+    as
+    associations
+    for
+    blind
+    and
+    dyslexic
+    persons
+    48
+    
+    25
+    
+    The Marrakesh Treaty50 has been adopted to facilitate access to published works for persons
+    who are blind, visually impaired, or otherwise print disabled. The Treaty creates a mandatory
+    exception to copyright that allows organisations for the blind to produce, distribute and make
+    available accessible format copies to visually impaired persons without the authorisation of
+    the rightholders. The EU and its Member States have started work to sign and ratify the
+    Treaty. This may require the adoption of certain provisions at EU level (e.g. to ensure the
+    possibility to exchange accessible format copies across borders).
+050 50.
+050 (a) [In particular if you are a person with a disability or an organisation representing
+050 persons with disabilities:] Have you experienced problems with accessibility to content,
+050 including across borders, arising from Member States’ implementation of this exception?
+050 (b) [In particular if you are an organisation providing services for persons with disabilities:]
+050 Have you experienced problems when distributing/communicating works published in
+050 special formats across the EU?
+050 (c) [In particular if you are a right holder:] Have you experienced specific problems
+050 resulting from the application of limitations or exceptions allowing for the
+050 distribution/communication of works published in special formats, including across
+050 borders?
+    YES – Please explain by giving examples
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+051 51.
+051 
+051 If there are problems, what could be done to improve accessibility?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+052 52.
+052 What mechanisms exist in the market place to facilitate accessibility to content?
+052 How successful are they?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    (http://ec.europa.eu/internal_market/copyright/initiatives/access/index_en.htm) and the Trusted Intermediary
+    Global Accessible Resources (TIGAR) project in WIPO (http://www.visionip.org/portal/en/).
+    50
+    Marrakesh Treaty to Facilitate Access to Published Works by Visually Impaired Persons and Persons with
+    Print Disabilities, Marrakesh, June 17 to 28 2013.
+    
+    26
+    
+    E.
+    
+    Text and data mining
+    
+    Text and data mining/content mining/data analytics51 are different terms used to describe
+    increasingly important techniques used in particular by researchers for the exploration of vast
+    amounts of existing texts and data (e.g., journals, web sites, databases etc.). Through the use
+    of software or other automated processes, an analysis is made of relevant texts and data in
+    order to obtain new insights, patterns and trends.
+    The texts and data used for mining are either freely accessible on the internet or accessible
+    through subscriptions to e.g. journals and periodicals that give access to the databases of
+    publishers. A copy is made of the relevant texts and data (e.g. on browser cache memories or
+    in computers RAM memories or onto the hard disk of a computer), prior to the actual
+    analysis. Normally, it is considered that to mine protected works or other subject matter, it is
+    necessary to obtain authorisation from the right holders for the making of such copies unless
+    such authorisation can be implied (e.g. content accessible to general public without
+    restrictions on the internet, open access).
+    Some argue that the copies required for text and data mining are covered by the exception for
+    temporary copies in Article 5.1 of Directive 2001/29/EC. Others consider that text and data
+    mining activities should not even be seen as covered by copyright. None of this is clear, in
+    particular since text and data mining does not consist only of a single method, but can be
+    undertaken in several different ways. Important questions also remain as to whether the main
+    problems arising in relation to this issue go beyond copyright (i.e. beyond the necessity or not
+    to obtain the authorisation to use content) and relate rather to the need to obtain “access” to
+    content (i.e. being able to use e.g. commercial databases).
+    A specific Working Group was set up on this issue in the framework of the "Licences for
+    Europe" stakeholder dialogue. No consensus was reached among participating stakeholders
+    on either the problems to be addressed or the results. At the same time, practical solutions to
+    facilitate text and data mining of subscription-based scientific content were presented by
+    publishers as an outcome of “Licences for Europe”52. In the context of these discussions,
+    other stakeholders argued that no additional licences should be required to mine material to
+    which access has been provided through a subscription agreement and considered that
+    a specific exception for text and data mining should be introduced, possibly on the basis of
+    a distinction between commercial and non-commercial.
+053 53.
+053 (a) [In particular if you are an end user/consumer or an institutional user:] Have you
+053 experienced obstacles, linked to copyright, when trying to use text or data mining methods,
+053 including across borders?
+053 (b) [In particular if you are a service provider:] Have you experienced obstacles, linked to
+053 copyright, when providing services based on text or data mining methods, including across
+053 borders?
+053 (c) [In particular if you are a right holder:] Have you experienced specific problems
+053 resulting from the use of text and data mining in relation to copyright protected content,
+053 including across borders?
+    YES – Please explain
+    51
+    
+    For the purpose of the present document, the term “text and data mining” will be used.
+    See the document “Licences for Europe – ten pledges to bring more content online”:
+    http://ec.europa.eu/internal_market/copyright/docs/licences-for-europe/131113_ten-pledges_en.pdf .
+    52
+    
+    27
+    
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+054 54.
+054 
+054 If there are problems, how would they best be solved?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+055 55.
+055 If your view is that a legislative solution is needed, what would be its main
+055 elements? Which activities should be covered and under what conditions?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+056 56.
+056 
+056 If your view is that a different solution is needed, what would it be?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+057 57.
+057 Are there other issues, unrelated to copyright, that constitute barriers to the use of
+057 text or data mining methods?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    F.
+    
+    User-generated content
+    
+    Technological and service developments mean that citizens can copy, use and distribute
+    content at little to no financial cost. As a consequence, new types of online activities are
+    developing rapidly, including the making of so-called “user-generated content”. While users
+    can create totally original content, they can also take one or several pre-existing works,
+    change something in the work(s), and upload the result on the Internet e.g. to platforms and
+    blogs53. User-generated content (UGC) can thus cover the modification of pre-existing works
+    even if the newly-generated/"uploaded" work does not necessarily require a creative effort
+    53
+    
+    A typical example could be the “kitchen” or “wedding” video (adding one's own video to a pre-existing sound
+    recording), or adding one's own text to a pre-existing photograph. Other examples are “mash-ups” (blending two
+    sound recordings), and reproducing parts of journalistic work (report, review etc.) in a blog.
+    
+    28
+    
+    and results from merely adding, subtracting or associating some pre-existing content with
+    other pre-existing content. This kind of activity is not “new” as such. However, the
+    development of social networking and social media sites that enable users to share content
+    widely has vastly changed the scale of such activities and increased the potential economic
+    impact for those holding rights in the pre-existing works. Re-use is no longer the preserve of
+    a technically and artistically adept elite. With the possibilities offered by the new
+    technologies, re-use is open to all, at no cost. This in turn raises questions with regard to
+    fundamental rights such the freedom of expression and the right to property.
+    A specific Working Group was set up on this issue in the framework of the "Licences for
+    Europe" stakeholder dialogue. No consensus was reached among participating stakeholders
+    on either the problems to be addressed or the results or even the definition of UGC.
+    Nevertheless, a wide range of views were presented as to the best way to respond to this
+    phenomenon. One view was to say that a new exception is needed to cover UGC, in particular
+    non-commercial activities by individuals such as combining existing musical works with
+    videos, sequences of photos, etc. Another view was that no legislative change is needed: UGC
+    is flourishing, and licensing schemes are increasingly available (licence schemes concluded
+    between rightholders and platforms as well as micro-licences concluded between rightholders
+    and the users generating the content. In any event, practical solutions to ease user-generated
+    content and facilitate micro-licensing for small users were pledged by rightholders across
+    different sectors as a result of the “Licences for Europe” discussions54.
+058 58.
+058 (a) [In particular if you are an end user/consumer:] Have you experienced problems
+058 when trying to use pre-existing works or other subject matter to disseminate new content on
+058 the Internet, including across borders?
+058 (b) [In particular if you are a service provider:] Have you experienced problems when users
+058 publish/disseminate new content based on the pre-existing works or other subject-matter
+058 through your service, including across borders?
+058 (c) [In particular if you are a right holder:] Have you experienced problems resulting from
+058 the way the users are using pre-existing works or other subject-matter to disseminate new
+058 content on the Internet, including across borders?
+    YES – Please explain by giving examples
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO
+    NO OPINION
+059 59.
+059 (a) [In particular if you are an end user/consumer or a right holder:] Have you
+059 experienced problems when trying to ensure that the work you have created (on the basis of
+059 pre-existing works) is properly identified for online use? Are proprietary systems sufficient
+059 in this context?
+059 (b) [In particular if you are a service provider:] Do you provide possibilities for users that
+059 are publishing/disseminating the works they have created (on the basis of pre-existing
+059 works) through your service to properly identify these works for online use?
+    54
+    
+    See the document “Licences for Europe – ten pledges to bring more content online”:
+    http://ec.europa.eu/internal_market/copyright/docs/licences-for-europe/131113_ten-pledges_en.pdf .
+    
+    29
+    
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+060 60.
+060 (a) [In particular if you are an end user/consumer or a right holder):] Have you
+060 experienced problems when trying to be remunerated for the use of the work you have
+060 created (on the basis of pre-existing works)?
+060 (b) [In particular if you are a service provider:] Do you provide remuneration schemes for
+060 users publishing/disseminating the works they have created (on the basis of pre-existing
+060 works) through your service?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+061 61.
+061 
+061 If there are problems, how would they best be solved?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+062 62.
+062 If your view is that a legislative solution is needed, what would be its main
+062 elements? Which activities should be covered and under what conditions?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+063 63.
+063 
+063 If your view is that a different solution is needed, what would it be?
+    
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    30
+    
+    IV.
+    
+    Private copying and reprography
+    
+    Directive 2001/29/EC enables Member States to implement in their national legislation
+    exceptions or limitations to the reproduction right for copies made for private use and
+    photocopying55. Levies are charges imposed at national level on goods typically used for such
+    purposes (blank media, recording equipment, photocopying machines, mobile listening
+    devices such as mp3/mp4 players, computers, etc.) with a view to compensating rightholders
+    for the harm they suffer when copies are made without their authorisation by certain
+    categories of persons (i.e. natural persons making copies for their private use) or through use
+    of certain technique (i.e. reprography). In that context, levies are important for rightholders.
+    With the constant developments in digital technology, the question arises as to whether the
+    copying of files by consumers/end-users who have purchased content online - e.g. when a
+    person has bought an MP3 file and goes on to store multiple copies of that file (in her
+    computer, her tablet and her mobile phone) - also triggers, or should trigger, the application of
+    private copying levies. It is argued that, in some cases, these levies may indeed be claimed by
+    rightholders whether or not the licence fee paid by the service provider already covers copies
+    made by the end user. This approach could potentially lead to instances of double payments
+    whereby levies could be claimed on top of service providers’ licence fees5657.
+    There is also an on-going discussion as to the application or not of levies to certain types of
+    cloud-based services such as personal lockers or personal video recorders.
+064 64.
+064 In your view, is there a need to clarify at the EU level the scope and application of
+064 the private copying and reprography exceptions58 in the digital environment?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+065 65.
+065 Should digital copies made by end users for private purposes in the context of
+065 a service that has been licensed by rightholders, and where the harm to the rightholder is
+065 minimal, be subject to private copying levies?59
+    – Please explain
+    55
+    
+    Article 5. 2)(a) and (b) of Directive 2001/29.
+    Communication "Unleashing the Potential of Cloud Computing in Europe", COM(2012) 529 final.
+    57
+    These issues were addressed in the recommendations of Mr António Vitorino resulting from the mediation on
+    private copying and reprography levies. You can consult these recommendations on the following website:
+    http://ec.europa.eu/internal_market/copyright/docs/levy_reform/130131_levies-vitorinorecommendations_en.pdf.
+    58
+    Art. 5.2(a) and 5.2(b) of Directive 2001/29/EC.
+    59
+    This issue was also addressed in the recommendations of Mr Antonio Vitorino resulting from the mediation on
+    private copying and reprography levies
+    56
+    
+    31
+    
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+066 66.
+066 How would changes in levies with respect to the application to online services (e.g.
+066 services based on cloud computing allowing, for instance, users to have copies on different
+066 devices) impact the development and functioning of new business models on the one hand
+066 and rightholders’ revenue on the other?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+067 67.
+067 Would you see an added value in making levies visible on the invoices for products
+    subject to levies?60
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+    Diverging national systems levy different products and apply different tariffs. This results in
+    obstacles to the free circulation of goods and services in the Single Market. At the same time,
+    many Member States continue to allow the indiscriminate application of private copying
+    levies to all transactions irrespective of the person to whom the product subject to a levy is
+    sold (e.g. private person or business). In that context, not all Member States have ex ante
+    exemption and/or ex post reimbursement schemes which could remedy these situations and
+    reduce the number of undue payments61.
+068 68.
+068 Have you experienced a situation where a cross-border transaction resulted in
+068 undue levy payments, or duplicate payments of the same levy, or other obstacles to the free
+068 movement of goods or services?
+    
+    60
+    
+    This issue was also addressed in the recommendations of Mr Antonio Vitorino resulting from the mediation on
+    private copying and reprography levies.
+    61
+    This issue was also addressed in the recommendations of Mr Antonio Vitorino resulting from the mediation on
+    private copying and reprography levies.
+    
+    32
+    
+    YES – Please specify the type of transaction and indicate the percentage of the undue
+    payments. Please also indicate how a priori exemption and/or ex post reimbursement schemes
+    could help to remedy the situation.
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+069 69.
+069 What percentage of products subject to a levy is sold to persons other than natural
+069 persons for purposes clearly unrelated to private copying? Do any of those transactions
+069 result in undue payments? Please explain in detail the example you provide (type of
+069 products, type of transaction, stakeholders, etc.).
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+070 70.
+070 Where such undue payments arise, what percentage of trade do they affect? To what
+070 extent could a priori exemptions and/or ex post reimbursement schemes existing in some
+070 Member States help to remedy the situation?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+071 71.
+071 If you have identified specific problems with the current functioning of the levy
+071 system, how would these problems best be solved?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    V.
+    
+    Fair remuneration of authors and performers
+    
+    The EU copyright acquis recognises for authors and performers a number of exclusive rights
+    and, in the case of performers whose performances are fixed in phonograms, remuneration
+    rights. There are few provisions in the EU copyright law governing the transfer of rights from
+    authors or performers to producers62 or determining who the owner of the rights is when the
+    work or other subject matter is created in the context of an employment contract63. This is an
+    area that has been traditionally left for Member States to regulate and there are significant
+    62
+    63
+    
+    See e.g. Directive 92/100/EEC, Art.2(4)-(7).
+    See e.g. Art. 2.3. of Directive 2009/24/EC, Art. 4 of Directive 96/9/EC.
+    
+    33
+    
+    differences in regulatory approaches. Substantial differences also exist between different
+    sectors of the creative industries.
+    Concerns continue to be raised that authors and performers are not adequately remunerated, in
+    particular but not solely, as regards online exploitation. Many consider that the economic
+    benefit of new forms of exploitation is not being fairly shared along the whole value chain.
+    Another commonly raised issue concerns contractual practices, negotiation mechanisms,
+    presumptions of transfer of rights, buy-out clauses and the lack of possibility to terminate
+    contracts. Some stakeholders are of the opinion that rules at national level do not suffice to
+    improve their situation and that action at EU level is necessary.
+072 72.
+072 [In particular if you are an author/performer:] What is the best mechanism (or
+072 combination of mechanisms) to ensure that you receive an adequate remuneration for the
+072 exploitation of your works and performances?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+073 73.
+073 Is there a need to act at the EU level (for instance to prohibit certain clauses in
+073 contracts)?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain why
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+074 74.
+074 If you consider that the current rules are not effective, what would you suggest to
+074 address the shortcomings you identify?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    VI.
+    
+    Respect for rights
+    
+    Directive 2004/48/EE64 provides for a harmonised framework for the civil enforcement of
+    intellectual property rights, including copyright and related rights. The Commission has
+    consulted broadly on this text65. Concerns have been raised as to whether some of its
+    provisions are still fit to ensure a proper respect for copyright in the digital age. On the one
+    64
+    
+    Directive 2004/48/EC of the European Parliament and of the Council of 29 April 2004 on the enforcement
+    of intellectual property rights.
+    65
+    You will find more information on the following website:
+    http://ec.europa.eu/internal_market/iprenforcement/directive/index_en.htm
+    
+    34
+    
+    hand, the current measures seem to be insufficient to deal with the new challenges brought by
+    the dissemination of digital content on the internet; on the other hand, there are concerns
+    about the current balance between enforcement of copyright and the protection of
+    fundamental rights, in particular the right for a private life and data protection. While it cannot
+    be contested that enforcement measures should always be available in case of infringement of
+    copyright, measures could be proposed to strengthen respect for copyright when the infringed
+    content is used for a commercial purpose66. One means to do this could be to clarify the role
+    of intermediaries in the IP infrastructure67. At the same time, there could be clarification of
+    the safeguards for respect of private life and data protection for private users.
+075 75.
+075 Should the civil enforcement system in the EU be rendered more efficient for
+075 infringements of copyright committed with a commercial purpose?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO OPINION
+076 76.
+076 In particular, is the current legal framework clear enough to allow for sufficient
+076 involvement of intermediaries (such as Internet service providers, advertising brokers,
+076 payment service providers, domain name registrars, etc.) in inhibiting online copyright
+076 infringements with a commercial purpose? If not, what measures would be useful to foster
+076 the cooperation of intermediaries?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+077 77.
+077 Does the current civil enforcement framework ensure that the right balance is
+077 achieved between the right to have one’s copyright respected and other rights such as the
+077 protection of private life and protection of personal data?
+    YES – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    NO – Please explain
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    66
+    
+    For example when the infringing content is offered on a website which gets advertising revenues that depend
+    on the volume of traffic.
+    67
+    This clarification should not affect the liability regime of intermediary service providers established by
+    Directive 2000/31/EC on electronic commerce, which will remain unchanged.
+    
+    35
+    
+    NO OPINION
+    
+    VII. A single EU Copyright Title
+    The idea of establishing a unified EU Copyright Title has been present in the copyright debate
+    for quite some time now, although views as to the merits and the feasibility of such an
+    objective are divided. A unified EU Copyright Title would totally harmonise the area of
+    copyright law in the EU and replace national laws. There would then be a single EU title
+    instead of a bundle of national rights. Some see this as the only manner in which a truly
+    Single Market for content protected by copyright can be ensured, while others believe that the
+    same objective can better be achieved by establishing a higher level of harmonisation while
+    allowing for a certain degree of flexibility and specificity in Member States’ legal systems.
+078 78.
+078 Should the EU pursue the establishment of a single EU Copyright Title, as a means
+078 of establishing a consistent framework for rights and exceptions to copyright across the
+078 EU, as well as a single framework for enforcement?
+    YES
+    NO
+    NO OPINION
+079 79.
+079 Should this be the next step in the development of copyright in the EU? Does the
+079 current level of difference among the Member State legislation mean that this is a longer
+079 term project?
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    VIII.
+    
+    Other issues
+    
+    The above questionnaire aims to provide a comprehensive consultation on the most important
+    matters relating to the current EU legal framework for copyright. Should any important
+    matters have been omitted, we would appreciate if you could bring them to our attention, so
+    they can be properly addressed in the future.
+080 80.
+080 Are there any other important matters related to the EU legal framework for
+080 copyright? Please explain and indicate how such matters should be addressed.
+    [Open question]
+    ……………………………………………………………………………………………….
+    ……………………………………………………………………………………………….
+    
+    36
+    
+    


### PR DESCRIPTION
I made a parser based on text comparisons. It removes all words which are already in the original consultation document, making note of where in that document it happens. When a word is encountered which is *not* in the consultation, it must be user-supplied, i.e. part of an answer. Answers come after the question, hence it is part of the answer to the last thing we removed.